### PR TITLE
修复验证码失效和关闭 shiro 重写 uri

### DIFF
--- a/src/main/java/cc/mrbird/common/shiro/ShiroConfig.java
+++ b/src/main/java/cc/mrbird/common/shiro/ShiroConfig.java
@@ -205,6 +205,7 @@ public class ShiroConfig {
         sessionManager.setGlobalSessionTimeout(febsProperties.getShiro().getSessionTimeout());
         sessionManager.setSessionListeners(listeners);
         sessionManager.setSessionDAO(redisSessionDAO());
+        sessionManager.setSessionIdUrlRewritingEnabled(false);
         return sessionManager;
     }
 }

--- a/src/main/java/cc/mrbird/system/controller/LoginController.java
+++ b/src/main/java/cc/mrbird/system/controller/LoginController.java
@@ -85,8 +85,8 @@ public class LoginController extends BaseController {
                     febsProperties.getValidateCode().getWidth(),
                     febsProperties.getValidateCode().getHeight(),
                     febsProperties.getValidateCode().getLength());
-            captcha.out(response.getOutputStream());
             HttpSession session = request.getSession(true);
+            captcha.out(response.getOutputStream());
             session.removeAttribute(CODE_KEY);
             session.setAttribute(CODE_KEY, captcha.text().toLowerCase());
         } catch (Exception e) {


### PR DESCRIPTION
1. 修复直接进 /login 验证码失效问题
感谢群里的 @大米 老哥指点
2. 关闭 shiro 重写 uri（这会导致 login.html 中 js 获取的 ctx 带有
JSESSIONID，登录方法拼接的url不正确）