### PR TITLE
修复多用户同时登录时按钮权限（功能权限）在redis缓存的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.crazycake</groupId>
             <artifactId>shiro-redis</artifactId>
-            <version>2.8.24</version>
+            <version>3.1.0</version>
         </dependency>
 
         <!-- shiro-thymeleaf -->

--- a/src/main/java/cc/mrbird/common/shiro/ShiroConfig.java
+++ b/src/main/java/cc/mrbird/common/shiro/ShiroConfig.java
@@ -59,7 +59,7 @@ public class ShiroConfig {
     private RedisManager redisManager() {
         RedisManager redisManager = new RedisManager();
         // 缓存时间，单位为秒
-        redisManager.setExpire(febsProperties.getShiro().getExpireIn());
+        //redisManager.setExpire(febsProperties.getShiro().getExpireIn()); // removed from shiro-redis v3.1.0 api
         redisManager.setHost(host);
         redisManager.setPort(port);
         if (StringUtils.isNotBlank(password))

--- a/src/main/java/cc/mrbird/system/domain/User.java
+++ b/src/main/java/cc/mrbird/system/domain/User.java
@@ -307,4 +307,16 @@ public class User implements Serializable {
 				", roleName='" + roleName + '\'' +
 				'}';
 	}
+
+	/**
+	 * shiro-redis v3.1.0 必须要有getAuthCacheKey()或者getId()方法
+	 * # Principal id field name. The field which you can get unique id to identify this principal.
+	 * # For example, if you use UserInfo as Principal class, the id field maybe userId, userName, email, etc.
+	 * # Remember to add getter to this id field. For example, getUserId(), getUserName(), getEmail(), etc.
+	 * # Default value is authCacheKey or id, that means your principal object has a method called "getAuthCacheKey()" or "getId()"
+	 * @return userId as Principal id field name
+	 */
+	public Long getAuthCacheKey() {
+		return userId;
+	}
 }


### PR DESCRIPTION
升级shiro-redis版本到3.1.0，解决低版本只缓存一个用户的按钮权限（功能权限）而导致拥有不同权限的用户在同时访问系统时候，功能权限无法区分的问题。