### PR TITLE
去除findMenuList的ORDER BY的多余的列

### DIFF
--- a/src/main/java/cc/mrbird/febs/system/service/impl/MenuServiceImpl.java
+++ b/src/main/java/cc/mrbird/febs/system/service/impl/MenuServiceImpl.java
@@ -65,7 +65,7 @@ public class MenuServiceImpl extends ServiceImpl<MenuMapper, Menu> implements IM
         if (StringUtils.isNotBlank(menu.getMenuName())) {
             queryWrapper.lambda().like(Menu::getMenuName, menu.getMenuName());
         }
-        queryWrapper.lambda().orderByAsc(Menu::getMenuId).orderByAsc(Menu::getOrderNum);
+        queryWrapper.lambda().orderByAsc(Menu::getMenuId);
         return this.baseMapper.selectList(queryWrapper);
     }
 


### PR DESCRIPTION
将findMenuList查询里`ORDER BY MENU_ID ASC, MENU_ORDER ASC`改为`ORDER BY MENU_ID ASC`

详见#172